### PR TITLE
Add script to automatically enable / disable second monitor (with vnc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You now success Add Fake Display with No Monitor is Plugged In!
 - libnotify
 
 ##### On the android phone/tablet :
-- VNCviewer, or any other vnc viewer for android
+- [VNCviewer](https://play.google.com/store/apps/details?id=com.realvnc.viewer.android), or any other vnc viewer for android
 
 ### Installation steps :
 1. Enable developer mode on the android phone/tablet by entering int settings -> info and tapping on the release number 5 times  

--- a/README.md
+++ b/README.md
@@ -81,6 +81,29 @@ Check teamviewer client and select your virtual display act as external monitor.
 
 You now success Add Fake Display with No Monitor is Plugged In!
 
+# VNC + Android Setup
+
+### Dependencies :
+
+##### On the linux machine :
+- x11vnc
+- android-tools
+- libnotify
+
+##### On the android phone/tablet :
+- VNCviewer, or any other vnc viewer for android
+
+### Installation steps :
+1. Enable developer mode on the android phone/tablet by entering int settings -> info and tapping on the release number 5 times  
+2. Enable USB-debugging in developer settings on the android device  
+3. Plug an USB cable between your two devices  
+3. b) Depending on the android version you may need to go to your notifications, and look for a notification about the USB connection to allow debugging.  
+4. Run `adb shell` on your Linux machine and approve the request on your android device  
+5. Configure the variables in the script, `internal` is your computer monitor, you should get it with `xrandr` and ``screen1`` and `virtual1` are the resolutions of the script  
+6. start the script  
+7. open the VNC app on your android device  
+8. connect to `http://127.0.0.1:5900`  
+
 ## Confirmed
 
 * Elementary OS 5.0 Juno based on Ubuntu 18.04 with *Teamviewer v.14.7.19.65*

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You now success Add Fake Display with No Monitor is Plugged In!
 3. Plug an USB cable between your two devices  
 3. b) Depending on the android version you may need to go to your notifications, and look for a notification about the USB connection to allow debugging.  
 4. Run `adb shell` on your Linux machine and approve the request on your android device  
-5. Configure the variables in the script, `internal` is your computer monitor, you should get it with `xrandr` and ``screen1`` and `virtual1` are the resolutions of the script  
+5. Configure the variables in the script, `internal` is your computer monitor, you should get it with `xrandr`. `screen1` and `virtual1` are the resolutions of the screens  
 6. start the script  
 7. open the VNC app on your android device  
 8. connect to `http://127.0.0.1:5900`  

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ You now success Add Fake Display with No Monitor is Plugged In!
 * Armbian 5.0 xrdp with Realvnc Client
 * Fedora 34 - Gnome 40 on Xorg with Deskreen
 * Debian 11 - KDE Plazma with Deskreen
+* Manjaro Rolling - Gnome 40 on Xorg with x11vnc (server) realvnc (client) adb (for better fluidity)
 * Waiting your report here.
 
 ## Remote Client

--- a/vnc-android
+++ b/vnc-android
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# ### Dependencies : ###
+# x11vnc (vnc server)
+# android-tools (adb, to make an usb connection between the android device and the computer)
+# libnotify (to allow notifications, because it's the only way to see that the chaos is done)
+
+internal="eDP1"
+screen1="2048x1152"
+virtual1="1920x1200"
+
+if [ -e /usr/share/X11/xorg.conf.d/20-intel.conf ]; then
+	if [[ $1 == "stop" ]]; then
+		adb reverse --remove-all
+		killall x11vnc
+		sleep 3
+		
+		echo "Starting chaos"
+
+		xrandr --output VIRTUAL1 --off
+		# This usually does not work on the first time,
+		# but works like a charm second time
+		xrandr --output VIRTUAL1 --off
+		xrandr
+
+		xrandr --delmode VIRTUAL1 "$virtual1"
+		xrandr --output "$internal" --primary --mode "$eDP1"
+		xrandr
+		sleep 3
+
+		notify-send "You can touch your computer without any fear, this is done"
+		exit 0;
+
+	else
+		xrandr --addmode VIRTUAL1 "$virtual1"
+		#sleep 3s
+
+		xrandr --output VIRTUAL1 --mode "$virtual1" --left-of "$internal"
+		#sleep 3s
+
+		xrandr
+		sleep 3s
+
+		adb reverse tcp:5900 tcp:5900
+		x11vnc -clip "$virtual1"+0+0 -localhost -multiptr
+
+		echo "Done"
+	fi;
+else
+	echo -e "Section \"Device\"\n    Identifier \"intelgpu0\"\n    Driver \"intel\"\n    Option \"VirtualHeads\" \"2\"\nEndSection" > /usr/share/X11/xorg.conf.d/20-intel.conf
+	echo "[vdl-monitor] You must reboot or relogin current session to finish setup"
+	sleep 10s
+fi;
+

--- a/vnc-android
+++ b/vnc-android
@@ -24,7 +24,7 @@ if [ -e /usr/share/X11/xorg.conf.d/20-intel.conf ]; then
 		xrandr
 
 		xrandr --delmode VIRTUAL1 "$virtual1"
-		xrandr --output "$internal" --primary --mode "$eDP1"
+		xrandr --output "$internal" --primary --mode "$screen1"
 		xrandr
 		sleep 3
 


### PR DESCRIPTION
Thanks for this awesome project !
I added a script that I made, which is a bit specific since it's only to use with vnc + adb but is a timesaver.
I used adb in this to prevent exposing vnc to the network (running with `-localhost`), but it could be adapted to run on the network if adb is not installed.

PS: you'll need to enable usb debugging in Android to use adb port forwarding